### PR TITLE
Fix typo: `tha` -> `that`, remove trailing semicolons

### DIFF
--- a/content/downloads/notebooks/PEP8LineLengths.ipynb
+++ b/content/downloads/notebooks/PEP8LineLengths.ipynb
@@ -308,7 +308,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It's clear tha many of these duplicates are just boiler-plate code or documentation standards that happen to appear often through the package; we may be able to clean up our histogram by plotting only the histogram of lengths of *unique* lines, by passing the ist through Python's ``set`` collection:"
+    "It's clear that many of these duplicates are just boiler-plate code or documentation standards that happen to appear often through the package; we may be able to clean up our histogram by plotting only the histogram of lengths of *unique* lines, by passing the ist through Python's ``set`` collection:"
    ]
   },
   {
@@ -329,7 +329,7 @@
    ],
    "source": [
     "lengths = [len(line) for line in set(iter_lines(numpy))]\n",
-    "plt.hist(lengths, bins=np.arange(125), histtype='step', linewidth=1);"
+    "plt.hist(lengths, bins=np.arange(125), histtype='step', linewidth=1)"
    ]
   },
   {
@@ -563,7 +563,7 @@
     "    return amplitude * stats.lognorm.pdf(x, scale=np.exp(mu), s=sigma)\n",
     "\n",
     "x = np.linspace(0, 100, 1000)\n",
-    "plt.plot(x, lognorm_model(x, 1000, 3.5, 0.7));"
+    "plt.plot(x, lognorm_model(x, 1000, 3.5, 0.7))"
    ]
   },
   {
@@ -610,7 +610,7 @@
     "                        method='Nelder-Mead')\n",
     "print(\"optimal parameters:\", opt.x)\n",
     "\n",
-    "plt.fill_between(lengths, lognorm_model(lengths, *opt.x), alpha=0.3, color='gray');"
+    "plt.fill_between(lengths, lognorm_model(lengths, *opt.x), alpha=0.3, color='gray')"
    ]
   },
   {
@@ -748,8 +748,8 @@
     "    plt.text(mode, std, ' ' + name + ' ', size=14,\n",
     "             ha=ha.get(name, 'left'), va=va.get(name, 'bottom'))\n",
     "plt.xlabel('mode of model', size=14)\n",
-    "plt.ylabel('std. deviation of model', size=14);\n",
-    "plt.xlim(30, 41);"
+    "plt.ylabel('std. deviation of model', size=14)\n",
+    "plt.xlim(30, 41)"
    ]
   },
   {


### PR DESCRIPTION
Thanks for the great blog post!

I noticed a single typo while reading your post and then found a few trailing semicolons while I was in the notebook fixing it.
