### PR TITLE
[blog] fix typo in WaitingTimeParadox

### DIFF
--- a/content/downloads/notebooks/WaitingTimeParadox.ipynb
+++ b/content/downloads/notebooks/WaitingTimeParadox.ipynb
@@ -63,7 +63,7 @@
     "\n",
     "In the case of a nominally 10-minute bus line, sometimes the span between arrivals will be longer than 10 minutes, and sometimes shorter, and if you arrive at a random time, you have more opportunities to encounter a longer interval than to encounter a shorter interval. And so it makes sense that the average span of time *experienced by riders* will be longer than the average span of time between buses, because the longer spans are over-sampled.\n",
     "\n",
-    "But the waiting time paradox makes a stronger claim than this: when the average span between arrivals is $N$ minutes, the average span *experienced by riders* is $2N$ minutes.\n",
+    "But the waiting time paradox makes a stronger claim than this: when the average span between arrivals is $N$ minutes, the average span *experienced by riders* is also $N$ minutes.\n",
     "Could this possibly be true?"
    ]
   },


### PR DESCRIPTION
The article clearly shows that for an estimated arrival time every 10 minutes, the average rider will also wait 10 mins (instead of 5 mins as expected), not 20 mins.

cc @jakevdp 